### PR TITLE
wget and plotting

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -65,7 +65,9 @@ else:
     csv_urls = ["https://www.dropbox.com/s/sdeouxrs7jrvss9/hires_telluric_mask.csv#",
                 "https://www.dropbox.com/s/wmdn6z67op2est0/detrend.csv#"]
     for f in csv_urls:
-        os.system("wget --no-check-certificate -P " + SPECMATCHDIR + " " + f)
+        outfile = os.path.join(SPECMATCHDIR,f.split('/')[-1][:-1])
+        cmd = "wget --no-check-certificate {} -O {}".format(f,outfile)
+        os.system(cmd)
 
     specdir = os.path.join(SPECMATCHDIR, 'spectra')
     if not os.path.exists(specdir):
@@ -76,11 +78,15 @@ else:
                     "https://www.dropbox.com/s/la0ojduaz5sf6pm/rj55.1872.fits#",
                     "https://www.dropbox.com/s/9pe7pwae489mjdw/rj59.1926.fits#"]
         for ref in ref_urls:
-            os.system("wget --no-check-certificate -P " + specdir + " " +
-                      ref)
+            outfile = os.path.join(specdir,ref.split('/')[-1][:-1])
+            cmd = "wget --no-check-certificate {} -O {}".format(ref,outfile)
+            os.system(cmd)
+
 
 #        from six.moves import urllib
 #        print("Downloading library.h5")
 #        urllib.request.urlretrieve(liburl, LIBPATH, reporthook)
+
+
 
 

--- a/specmatchemp/core.py
+++ b/specmatchemp/core.py
@@ -147,10 +147,15 @@ def plot_shifts(sm, pdf, order, wavlim='all', singleorder=False):
     plt.close()
 
     # Cross-correlation
-    fig = plt.figure(figsize=(10, 5))
+    fig, axL = plt.subplots(ncols=2, figsize=(10, 5))
+    plt.sca(axL[0])
     sm.plot_xcorr(order, True)
-    plt.title('{0} cross-correlation for order {1:d}'
-              .format(name, order))
+    plt.title('{0} cross-correlation for order {1:d}'.format(name, order))
+    plt.sca(axL[1])
+    sm.plot_xcorr(order,True)
+    meanshift = np.nanmean(sm.shift_data['fit'])
+    dpix = 30
+    plt.xlim(meanshift-dpix, meanshift+dpix)
     fig.set_tight_layout(True)
     pdf.savefig()
     plt.close()

--- a/specmatchemp/specmatch.py
+++ b/specmatchemp/specmatch.py
@@ -740,7 +740,7 @@ class SpecMatch(object):
         if orders == 'all':
             orders = np.arange(total_orders)
 
-        colormap = plt.cm.nipy_spectral_r
+        colormap = plt.cm.nipy_spectral
         num_orders = len(orders)
         for i in range(num_orders):
             color = colormap(0.9 * i / num_orders + 0.1)
@@ -765,7 +765,7 @@ class SpecMatch(object):
             highlightpeak (bool): Whether to highlight the peak value.
         """
         num_sects = self.shift_data['order_{0:d}/num_sections'.format(order)]
-        colormap = plt.cm.nipy_spectral_r
+        colormap = plt.cm.nipy_spectral
 
         for i in range(num_sects):
             color = colormap(0.9 * i / num_sects + 0.1)

--- a/specmatchemp/specmatch.py
+++ b/specmatchemp/specmatch.py
@@ -740,18 +740,22 @@ class SpecMatch(object):
         if orders == 'all':
             orders = np.arange(total_orders)
 
-        colormap = plt.cm.nipy_spectral
+        colormap = plt.cm.nipy_spectral_r
         num_orders = len(orders)
         for i in range(num_orders):
-            color = colormap(0.9 * (i / num_orders))
+            color = colormap(0.9 * i / num_orders + 0.1)
             order = orders[i]
-            plt.plot(center_pix[order], lags[order], 'o', color=color)
-            plt.plot(center_pix[order], fit[order], '-', color=color,
-                     label='Order {0:d}'.format(order))
+            plt.plot(
+                center_pix[order], lags[order], '_', ms=10, mew=4, color=color
+            )
+            plt.plot(
+                center_pix[order], fit[order], '-', color=color,
+                label='{0:d}'.format(order)
+            )
 
         plt.xlabel('Pixel number')
         plt.ylabel('Shift (pixels)')
-        plt.legend(loc='best', ncol=2, fontsize='small')
+        plt.legend(loc='best', ncol=2, fontsize='small',title='Order')
 
     def plot_xcorr(self, order=0, highlightpeak=False):
         """Plot the correlation array for each section of the given order.
@@ -761,18 +765,26 @@ class SpecMatch(object):
             highlightpeak (bool): Whether to highlight the peak value.
         """
         num_sects = self.shift_data['order_{0:d}/num_sections'.format(order)]
+        colormap = plt.cm.nipy_spectral_r
+
         for i in range(num_sects):
+            color = colormap(0.9 * i / num_sects + 0.1)
+
             xcorr = self.shift_data['order_{0:d}/sect_{1:d}/xcorr'
                                     .format(order, i)]
             lag_arr = self.shift_data['order_{0:d}/sect_{1:d}/lag_arr'
                                       .format(order, i)]
-            plt.plot(lag_arr, xcorr, label="Section {0:d}".format(i))
+            plt.plot(lag_arr, xcorr, label="{0:d}".format(i),color=color)
 
             if highlightpeak:
                 max_corr = np.argmax(xcorr)
-                plt.plot(lag_arr[max_corr], xcorr[max_corr], 'ko')
+                mew = plt.rcParams['lines.markeredgewidth'] * 4
+                plt.plot(
+                    lag_arr[max_corr], xcorr[max_corr],'x',color=color, 
+                    mew=mew,zorder=10
+                )
 
-        plt.legend(loc='upper left', fontsize='small')
+        plt.legend(loc='upper left', fontsize='small',title='Section')
         plt.xlabel('Shift (pixels)')
         plt.ylabel('Correlation')
 


### PR DESCRIPTION
made some small tweaks to the setup.py script so that the files get explicit names. My version of wget was downloading these files as `file` `file.1` `file.2` etc.

I also made some tweaks to the shifting diagnostic plots.
![image](https://cloud.githubusercontent.com/assets/694371/18817627/4103bce2-831a-11e6-96da-4a28de0b0e51.png)

![image](https://cloud.githubusercontent.com/assets/694371/18817633/68b54fbc-831a-11e6-8d80-ed6e74344bf7.png)

blue to red goes in order of increasing wavelength.

I've notice that there are still some outliers in the shift values, and it probably makes sense to implement some iterative outlier rejection. I could image a scheme along the following lines:

1. Compute a robust fit to shift vs. pixel value
2. Compute a robust sigma about this best fit (e.g. median absolute deviation)
3. If a given segment yields a shift that's more than 2 sigma from the robust fit, replace it with the robust value
4. Fit each order independently using the cleaned shift vs. pixel values.


