### PR TITLE
Patch debug

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -1,7 +1,7 @@
 .. _installation:
 
 Installation
-=============
+============
 
 Simply run 
 
@@ -13,15 +13,22 @@ This downloads all dependencies and data files, and creates the
 command line scripts. 
 
 Software dependencies
-~~~~~~~~~~~~~~~~~~~~~
+---------------------
+
+To install
+
+- wget (facilitates downloading files).
+
+Python Packages
+
 To use SpecMatch-Emp:
 
 - numpy
 - scipy
 - matplotlib
 - h5py
-- pandas
-- lmfit
+- pandas (>=0.18)
+- lmfit (>=0.9)
 
 To build library:
 

--- a/specmatchemp/cli.py
+++ b/specmatchemp/cli.py
@@ -7,14 +7,31 @@ import os
 import sys
 from argparse import ArgumentParser
 
+import numpy as np
+
 from specmatchemp import core
+from specmatchemp import library 
 from specmatchemp import SPECMATCHDIR
 
+NSPEC_DEBUG = 25
 
 def specmatch_spectrum(args):
-    core.specmatch_spectrum(args.spectrum, plot_level=args.plots,
-                            inlib=args.in_library, outdir=args.outdir,
-                            num_best=args.num_best, suffix=args.suffix)
+    lib_subset = None
+    if args.debug:
+        lib = library.read_hdf(wavlim='none')
+        nspec = len(lib.library_params)
+        lib_subset = np.random.choice(
+            np.arange(nspec), size=NSPEC_DEBUG, replace=False
+        )
+        lib_subset = np.sort(lib_subset)
+        lib_subset = list(lib_subset)
+
+
+    core.specmatch_spectrum(
+        args.spectrum, plot_level=args.plots,inlib=args.in_library, 
+        outdir=args.outdir, num_best=args.num_best, suffix=args.suffix, 
+        lib_subset=lib_subset
+    )
 
 
 def match_spectrum(args):
@@ -66,6 +83,9 @@ def main():
                         "combination step.")
     psr_sm.add_argument("-s", "--suffix", type=str, default="",
                         help="Suffix to append to results files")
+    psr_sm.add_argument("-d", "--debug", action='store_true',
+                        help="Run with paired down library")
+
     psr_sm.set_defaults(func=specmatch_spectrum)
 
     psr_shift = subpsr.add_parser("shift")

--- a/specmatchemp/library.py
+++ b/specmatchemp/library.py
@@ -765,13 +765,15 @@ def read_hdf(path=None, wavlim='all', lib_index_subset=None):
             The upper and lower wavelength limits to be read.
             If 'none', reads in library without spectra.
             If 'all', reads in complete stored spectra.
-        lib_index_subset (optional):
-            None - read in all spectra
-            List or np.s_ object: 
+        lib_index_subset (iterable, optional): Load a subset of the library
+            useful for debuging and testing code. May be a list or a np.s_ 
+            object. If passing a list, it must be in strictly increasing order
+            due to the memory access protocol of h5py.
 
     Returns:
         Library: Library object
     """
+
     if path is None:
         return read_hdf(LIBPATH, wavlim, lib_index_subset)
 


### PR DESCRIPTION
Added an option in the `specmatch` CLI to support a paired-down library. Note that if passing in a list to  `lib_subset`, it must be ordered based on how h5py accesses memory. 