### PR TITLE
Updated installation git command

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -11,7 +11,7 @@ or clone git repo
 
 ::
 
-    $ git clone git@github.com:samuelyeewl/specmatch-emp.git
+    $ git clone https://github.com/samuelyeewl/specmatch-emp
 
 Then, simply run 
 


### PR DESCRIPTION
Changed the URL for the git clone because the old one gave me the following error:

   Permission denied (publickey).
   fatal: Could not read from remote repository.