### PR TITLE
Add uncertainties to non-detrended values.

### DIFF
--- a/specmatchemp/specmatch.py
+++ b/specmatchemp/specmatch.py
@@ -330,17 +330,17 @@ class SpecMatch(object):
             self.lincomb_results.append(lincomb_results)
             self.coeffs.append(coeffs)
 
+        # Read in uncertainties
+        self._read_uncertainties()        
+            
         # Average over all wavelength regions
         for p in Library.STAR_PROPS:
             self.results_nodetrend[p] = 0
             for i in range(len(lincomb_regions)):
                 self.results_nodetrend[p] += (self.lincomb_results[i][p] /
                                               len(lincomb_regions))
-                # TODO: Add uncertainties
-                self.results_nodetrend['u_'+p] = 0.0
-
-        # Read in uncertainties
-        self._read_uncertainties()
+           # Add uncertainties
+           self.results_nodetrend['u_'+p] = self._get_uncertainty(self.results_nodetrend[p], p)
 
         # Detrend parameters
         d = detrend.Detrend()


### PR DESCRIPTION
Add uncertainties to non-detrended values when a detrend.csv file is provided (assuming same uncertainties between detrended and non-detrended values). Previously, if a detrend.csv file was provided the non-detrended uncertainties were set to zero.